### PR TITLE
Verankerung des Plenums als ein Organ des Vereins

### DIFF
--- a/Satzung.tex
+++ b/Satzung.tex
@@ -179,8 +179,32 @@
 	\item Die Organe des Vereins sind:
 		\begin{itemize}
 			\item Die Mitgliederversammlung;
+			\item Das Plenum;
 			\item Der Vorstand.
 		\end{itemize}
+\end{enumerate}
+
+\section{Plenum}
+\begin{enumerate}
+	\item Das Plenum findet in einem monatlichen Rythmus statt. Dabei obliegt es dem Vorstand
+	        zu einem Plenum einzuladen. In wichtigen Fällen kann ein Plenum durch den Vorstand 
+	        verschoben oder abgesagt werden. Ein abgesagtes Plenum bedarf keines Ersatztermines. 
+	        Wird ein Plenum abgesagt, muss das im Folgemonat geplante Plenum stattfinden.
+	
+	\item Das Plenum hat die Aufgabe, Handlungsempfehlungen sowie Aufträge für den 
+	        täglichen Umgang und Erfüllug der in dieser Satzung definierten Ziele 
+	        an den Vorstandes zu geben.
+	
+	\item Beschlüsse werden vom Plenum durch öffentliche Abstimmung mit einfacher Mehrheit 
+	        getroffen. Abstimmung durch Zustimmung ist bei verschiedenen Alternativvorschlägen 
+	        möglich.
+	
+	\item Das Plenum ist offen für alle Vereinsmitglieder und Gäste. Jeder Teilnehmer 
+	        hat eine Stimme.
+	
+	\item Dem Vorstand obliegt ein Veto-Recht für erteilte Aufträge, welches
+	        durch Anrufung der Mitgliederversammlung üerprüft werden kann. Der 
+	        Mitgliederversammlung obliegt in Folge die finale Entscheidung.
 \end{enumerate}
 
 \section{Mitgliederversammlung}


### PR DESCRIPTION
Die Idee ist, dem Plenum ein wenig mehr Verantwortung und Bedeutung zu geben. Mit dieser Satzungsänderung soll dem Plenum die Möglichkeit gegeben werden, direkt auf die Arbeit des Vorstands Einfluss zu nehmen und somit eine direkte Legitimierung für Fragen des täglichen Doings geschaffen werden.
Ferner soll damit das Problem korrigiert werden, dass Aufgaben im "jemand müsste mal" versanden in dem der Vorstand per default Verantwortlich für die Durchführung/Umsetzung ist
